### PR TITLE
Add export for the attachHelpers so they can be reattached 

### DIFF
--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ function routeTester(verb) {
   };
 }
 
+exports.attachHelpers = attachHelpers;
 function attachHelpers(req, obj) {
   var oldUser = req.user;
   obj.user = req.user || Object.create(defaultUser);


### PR DESCRIPTION
This allows for the helpers to be "reattched" at a later point.

For example: If you have a Express project that is separated into the MVC example.

As seen in 
https://github.com/madhums/nodejs-express-mongoose-demo
https://github.com/madhums/node-genem
