### PR TITLE
Override default request object name

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,20 @@ var defaultUser = {};
 var userProperty = 'user';
 
 
-var exports = module.exports = function middleware(req, res, next) {
+var exports = module.exports;
+
+exports.initialize = initialize;
+function initialize(options) {
+  if(options) {
+    failureHandler = options.failureHandler || failureHandler;
+    defaultUser = options.defaultUser || defaultUser;
+    userProperty = options.userProperty || userProperty;
+  }
+
+  return middleware;
+};
+
+function middleware(req, res, next) {
   if (res.locals) attachHelpers(req, res.locals);
   attachHelpers(req, req);
   next();
@@ -69,22 +82,6 @@ function isAuthenticated(req,res,next) {
   else if(req[userProperty]){ failureHandler(req, res, "isAuthenticated"); }
   else { throw new Error("Request[userProperty] was null or undefined, include middleware"); }
 };
-
-exports.setFailureHandler = setFailureHandler;
-function setFailureHandler(fn) {
-  failureHandler = fn;
-};
-
-exports.setDefaultUser = setDefaultUser;
-function setDefaultUser(user) {
-  defaultUser = user;
-};
-
-exports.setUserProperty = setUserProperty;
-function setUserProperty(userProp) {
-  userProperty = userProp;
-};
-
 
 function tester(req, verb){
   return function(action){

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,13 @@
 var roles = require('../');
 var assert = require('should');
+var middleware = roles.initialize();
 
 describe('middleware', function () {
     describe('when there is a user', function () {
         it('adds methods', function (done) {
             var req = {user: { id: 'Forbes' }};
             var res = {};
-            roles(req, res, function (err) {
+            middleware(req, res, function (err) {
                 if (err) return done(err);
                 req.user.isAuthenticated.should.equal(true);
                 req.user.can.should.be.a('function');
@@ -17,7 +18,7 @@ describe('middleware', function () {
         it('adds locals', function (done) {
             var req = {user: { id: 'Forbes' }};
             var res = {locals: {}};
-            roles(req, res, function (err) {
+            middleware(req, res, function (err) {
                 if (err) return done(err);
                 req.user.isAuthenticated.should.equal(true);
                 req.user.can.should.be.a('function');
@@ -33,7 +34,7 @@ describe('middleware', function () {
         it('adds methods and the anonymous user', function (done) {
             var req = {};
             var res = {};
-            roles(req, res, function (err) {
+            middleware(req, res, function (err) {
                 if (err) return done(err);
                 req.user.isAuthenticated.should.equal(false);
                 req.user.can.should.be.a('function');
@@ -44,7 +45,7 @@ describe('middleware', function () {
         it('adds locals for the anonymous user', function (done) {
             var req = {};
             var res = {locals: {}};
-            roles(req, res, function (err) {
+            middleware(req, res, function (err) {
                 if (err) return done(err);
                 req.user.isAuthenticated.should.equal(false);
                 req.user.can.should.be.a('function');
@@ -66,7 +67,7 @@ function notCalled(name) {
 describe('isAuthenticated route middleware', function () {
     describe('when there is a user', function () {
         before(function () {
-            roles.setFailureHandler(notCalled('Failure Handler'));
+            roles.initialize({failureHandler: notCalled('Failure Handler')});
         });
         it('passes the test', function (done) {
             var req = {user: { isAuthenticated: true }};
@@ -77,9 +78,9 @@ describe('isAuthenticated route middleware', function () {
             });
         });
         after(function () {
-            roles.setFailureHandler(function failureHandler(req, res, action) {
+            roles.initialize({failureHandler: function failureHandler(req, res, action) {
                 res.send(403);
-            });
+            }});
         });
     });
     describe('when there is a user but they aren\'t authenticated.', function () {
@@ -97,7 +98,7 @@ describe('isAuthenticated route middleware', function () {
         it('adds methods and the anonymous user', function (done) {
             var req = {};
             var res = {};
-            roles(req, res, function (err) {
+            middleware(req, res, function (err) {
                 if (err) return done(err);
                 req.user.isAuthenticated.should.equal(false);
                 req.user.can.should.be.a('function');


### PR DESCRIPTION
Hi ForbesLindesay :) I thought this might be a useful feature for others as well - the ability to choose the name of the role user object attached to the request object. Passport has a similar function, which I find useful. If you are not crazy about this change, no problem, or if you would like me to make some adjustments before acceptance, please let me know. I am happy to do so. Thank you kindly for the great lib.
-porkchop
