### PR TITLE
 Better error checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ function routeTester(verb) {
   return function (action){
     return function (req, res, next) {
       var act = ert(req, action);
-      if(tester(req,verb)(act)){
+      if(req.user && tester(req,verb)(act)){
         next();
       }else{
         //Failed authentication.


### PR DESCRIPTION
Make sure that the user object exists before trying to inspect properties on user.

Prior to this change, the failureHandler would never be called because the Express error handler would capture the attempt to reference id on user, which in some cases user is undefined.
