### PR TITLE
don't assume there is a req.user in the debug statement. fixes #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ function tester(req, verb){
         result = vote
       }
     }
+    var user = req.user || {};
     debug('Check Permission: ' + ((req.user && (req.user.id||req.user.name))||"user") +
         "." + (verb || 'can') + "('" + action + "') -> " + (result === true));
     return (result === true);


### PR DESCRIPTION
Assuming there is a `req.user` is throwing an error when a user is not authenticated. I've added a simple work-around for this, to get either the `req.user` or `{}` if that does not exist, and make the debug check against that. Fixes #21
