### PR TITLE
Fixed a typo, ==== produces a syntax error, should only be 3

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ user.use(function (req, action) {
 //they might not be the only one so we don't return
 //false if the user isn't a moderator
 user.use('access private page', function (req) {
-  if (req.user.role ==== 'moderator') {
+  if (req.user.role === 'moderator') {
     return true;
   }
 })


### PR DESCRIPTION
I copy and pasted that command and it created a syntax error so I thought I would fix it for you.
