### PR TITLE
replace deprecated Promise.from()

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ ConnectRoles.prototype.test = function (req, action) {
         if (typeof result === 'boolean') return result;
         else return fn(req, action);
       });
-    }, Promise.from(null)).then(function (result) {
+    }, Promise.resolve(null)).then(function (result) {
       if (typeof result == 'boolean') return result;
       else return false;
     });


### PR DESCRIPTION
Promise.from looks to be deprecated from the Promise module.  I replaced with Promise.resolve